### PR TITLE
New fault injection type for raft server testing

### DIFF
--- a/scripts/ctl-interface-cmds/fault-num-remaining.cmd
+++ b/scripts/ctl-interface-cmds/fault-num-remaining.cmd
@@ -1,0 +1,3 @@
+APPLY num_remaining@90
+WHERE /fault_injection_points/name@raft_follower_ignores_non_hb_AE_request
+OUTFILE /err.out

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -6,6 +6,7 @@
 #ifndef NIOVA_UTIL_H
 #define NIOVA_UTIL_H 1
 
+#include <limits.h>
 #include <stdio.h>
 #include <uuid/uuid.h>
 #include <ctype.h>
@@ -349,6 +350,25 @@ niova_string_to_bool(const char *string, bool *ret_bool)
         *ret_bool = false;
     else
         return -EINVAL;
+
+    return 0;
+}
+
+static inline unsigned int
+niova_string_to_unsigned_int(const char *string, unsigned int *val)
+{
+    if (!string || !val)
+        return -EINVAL;
+
+    unsigned long tmp = strtoul(string, NULL, 10);
+    if (tmp == ULONG_MAX)
+        return -errno;
+
+    else if (tmp > UINT_MAX)
+        return -EOVERFLOW;
+
+    else
+        *val = (unsigned int)tmp;
 
     return 0;
 }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -2213,8 +2213,9 @@ raft_server_write_new_entry_from_leader(
     NIOVA_ASSERT(ri && raerq);
     NIOVA_ASSERT(raft_instance_is_follower(ri));
 
-    if (raerq->raerqm_heartbeat_msg)
-        return; // This is a heartbeat msg which does not enter the log
+    if (raerq->raerqm_heartbeat_msg || // heartbeats don't enter the log
+        FAULT_INJECT(raft_follower_ignores_AE))
+        return;
 
     NIOVA_ASSERT(raerq->raerqm_log_term > 0);
     NIOVA_ASSERT(raerq->raerqm_log_term >= raerq->raerqm_prev_log_term);


### PR DESCRIPTION
FAULT_INJECT_PERIOD_every_time_unless_bypassed has been added which
will fire until the num_remaining value is no longer > 0.  This patch
allows for modification of "num_remaining" through the ctl-interface.

The reason for this addition is so that certain operations may proceed
in a strictly controlled manner.  For instance, let's say the fault will
cause recv'd msgs to be ignored every time, however, a test case
requires that one msg be let through.  This feature will allow for that
level of control by allowing a set number of operations through the
logic gate barrier created by the fault injection.

A new fault has been added, raft_follower_ignores_non_hb_AE_request,
which uses this new fault type:

{
                "name" : "raft_follower_ignores_non_hb_AE_request",
                "enabled" : true,
                "file" : "src/raft_server.c",
                "function" : "raft_server_write_new_entry_from_leader",
                "line_number" : 2217,
                "when_to_inject" : "every-time-unless-bypassed",
                "last_injected_at" : "Thu Oct 01 17:36:43 UTC 2020",
                "last_bypassed_at" : "Thu Oct 01 17:36:36 UTC 2020",
                "injection_count" : 72624,
                "frequency_seconds" : 0,
                "num_remaining" : 0,
                "cond_exec_count" : 72714
}

"last_bypassed_at" has also been added to show the time at which the
most recent bypass of the fault has occurred.