### PR TITLE
Increased CTLIC_MAX_VALUE_SIZE value to NAME_MAX + 1.

### DIFF
--- a/src/ctl_interface_cmd.c
+++ b/src/ctl_interface_cmd.c
@@ -27,7 +27,7 @@ REGISTRY_ENTRY_FILE_GENERATE;
 
 #define CTLIC_BUFFER_SIZE        4096
 #define CTLIC_MAX_TOKENS_PER_REQ 8
-#define CTLIC_MAX_VALUE_SIZE     127
+#define CTLIC_MAX_VALUE_SIZE     (NAME_MAX + 1)
 #define CTLIC_MAX_VALUE_DEPTH    32 // Max 'tree' depth which can be queried
 #define CTLIC_MAX_TAB_DEPTH      (CTLIC_MAX_VALUE_DEPTH * 2)
 #define CTLIC_MAX_SIBLING_CNT    16384


### PR DESCRIPTION
During holon recipe implementation, it has been
observed that even if input file name is less
than NAME_MAX (255) chars, the ctlreq parsing
was failing and it was not creating output file
for the cmd.
Increased CTLIC_MAX_VALUE_SIZE value to
NAME_MAX + 1 as per system name max limitation.