### PR TITLE
Issue#109 Corrected data type for var in pmdb_sm_handler_client_read

### DIFF
--- a/src/pumice_db.c
+++ b/src/pumice_db.c
@@ -572,7 +572,7 @@ pmdb_sm_handler_client_read(struct raft_net_client_request_handle *rncr)
 
     // Lookup the 'root' object
     struct pmdb_object obj = {0};
-    size_t rrc = pmdb_object_lookup(&pmdb_req->pmdbrm_user_id, &obj,
+    ssize_t rrc = pmdb_object_lookup(&pmdb_req->pmdbrm_user_id, &obj,
                                     rncr->rncr_current_term);
 
     if (!rrc)   // Ok.  Continue to read operation


### PR DESCRIPTION
In pmdb_sm_handler_client_read() unsigned size_t was used
to store return value of pmdb_object_lookup().
But the return value was checked for negative error code.
Which was making recipe fail as it expects the status to
be ENOENT and E2BIG was return.
Changed the data type to ssize_t.