### PR TITLE
Don't compare rncui for read operation.

### DIFF
--- a/go/pumiceDB/server/PumiceDBServer.go
+++ b/go/pumiceDB/server/PumiceDBServer.go
@@ -167,7 +167,7 @@ func PmdbStartServer(pso *PmdbServerObject) error {
 
 	// Starting the pmdb server.
 	rc := C.PmdbExec(raft_uuid_c, peer_uuid_c, &cCallbacks, cf_array, 1, true,
-		opa_ptr)
+		true, opa_ptr)
 	if rc != 0 {
 		return fmt.Errorf("PmdbExec() returned %d", rc)
 	}

--- a/src/include/pumice_db.h
+++ b/src/include/pumice_db.h
@@ -87,7 +87,8 @@ PmdbWriteKV(const struct raft_net_client_user_id *, void *pmdb_handle,
 int
 PmdbExec(const char *raft_uuid_str, const char *raft_instance_uuid_str,
          const struct PmdbAPI *pmdb_api, const char *cf_names[],
-         int num_cf, bool use_synchronous_writes, void *user_data);
+         int num_cf, bool use_synchronous_writes,
+         bool ignore_rncui, void *user_data);
 
 /**
  * PmdbClose - called from application context to shutdown the pumicedb exec

--- a/test/pumice-reference-server.c
+++ b/test/pumice-reference-server.c
@@ -359,5 +359,5 @@ main(int argc, char **argv)
     const char *cf_names[1] = {pmdbts_column_family_name};
 
     return PmdbExec(raft_uuid_str, my_uuid_str, &api, cf_names, 1,
-                    syncPMDBWrites, NULL);
+                    syncPMDBWrites, false, NULL);
 }


### PR DESCRIPTION
Most of the Pumicedb application do not have
to compare the rncui during read operation.
Addded parameter to PmdbExec() to set
ignore_rncui_check_during_read. This will allow the
read operation for the key even if rncui with which it
was written is not same.