### PR TITLE
Added raft_pvc_becomes_candidate fault injection.

### DIFF
--- a/src/fault_inject.c
+++ b/src/fault_inject.c
@@ -87,6 +87,11 @@ static struct fault_injection faultInjections[FAULT_INJECT__MAX] =
         .flti_when = FAULT_INJECT_PERIOD_every_time_unless_bypassed,
         .flti_enabled = 0,
     },
+    [FAULT_INJECT_raft_pvc_becomes_candidate] = {
+        .flti_name = "raft_pvc_becomes_candidate",
+        .flti_when = FAULT_INJECT_PERIOD_one_time_only,
+        .flti_enabled = 0,
+    },
     [FAULT_INJECT_disabled] = {
         .flti_name = "disabled injection",
         .flti_when = FAULT_INJECT_PERIOD_one_time_only,

--- a/src/include/fault_inject.h
+++ b/src/include/fault_inject.h
@@ -25,6 +25,7 @@ enum fault_inject_entries
     FAULT_INJECT_raft_client_udp_recv_handler_bypass,
     FAULT_INJECT_raft_client_udp_recv_handler_process_reply_bypass,
     FAULT_INJECT_raft_server_bypass_sm_apply,
+    FAULT_INJECT_raft_pvc_becomes_candidate,
     FAULT_INJECT__MAX,
     FAULT_INJECT__MIN = FAULT_INJECT_any,
 } PACKED;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -61,6 +61,9 @@ static unsigned long long raftServerMaxRecoveryLeaderCommMsec = 10000;
 static const char *
 raft_server_may_accept_client_request_reason(struct raft_instance *ri);
 
+static raft_net_timerfd_cb_ctx_t
+raft_server_become_candidate(struct raft_instance *ri, bool prevote);
+
 static raft_peer_t
 raft_server_instance_self_idx(const struct raft_instance *ri)
 {
@@ -1865,9 +1868,16 @@ raft_server_vote_for_self(struct raft_instance *ri)
         yes_vote = RAFT_VOTE_RESULT_YES;
     }
 
-    return raft_server_candidate_reg_vote_result(ri,
+    int rc = raft_server_candidate_reg_vote_result(ri,
                                                  RAFT_INSTANCE_2_SELF_UUID(ri),
                                                  yes_vote);
+    if (FAULT_INJECT(raft_pvc_becomes_candidate))
+    {
+        /* Force the prevote candidate to go into candidate state */
+        raft_server_become_candidate(ri, false);
+        return 0;
+    }
+    return rc;
 }
 
 static void


### PR DESCRIPTION
To test the corner case scenario where prevote
candidate is at higher term value than rest of
the cluster.