### PR TITLE
Don't compare rncui for read operation.

### DIFF
--- a/go/pumiceDB/server/PumiceDBServer.go
+++ b/go/pumiceDB/server/PumiceDBServer.go
@@ -167,7 +167,7 @@ func PmdbStartServer(pso *PmdbServerObject) error {
 
 	// Starting the pmdb server.
 	rc := C.PmdbExec(raft_uuid_c, peer_uuid_c, &cCallbacks, cf_array, 1, true,
-		opa_ptr)
+		true, opa_ptr)
 	if rc != 0 {
 		return fmt.Errorf("PmdbExec() returned %d", rc)
 	}

--- a/src/include/pumice_db.h
+++ b/src/include/pumice_db.h
@@ -87,7 +87,8 @@ PmdbWriteKV(const struct raft_net_client_user_id *, void *pmdb_handle,
 int
 PmdbExec(const char *raft_uuid_str, const char *raft_instance_uuid_str,
          const struct PmdbAPI *pmdb_api, const char *cf_names[],
-         int num_cf, bool use_synchronous_writes, void *user_data);
+         int num_cf, bool use_synchronous_writes,
+         bool ignore_rncui, void *user_data);
 
 /**
  * PmdbClose - called from application context to shutdown the pumicedb exec

--- a/src/pumice_db.c
+++ b/src/pumice_db.c
@@ -26,6 +26,7 @@ REGISTRY_ENTRY_FILE_GENERATE;
 
 static const struct PmdbAPI *pmdbApi;
 static void *pmdb_user_data = NULL;
+static bool dont_comp_rncui_for_rd = false;
 
 static struct raft_server_rocksdb_cf_table pmdbCFT = {0};
 
@@ -549,7 +550,7 @@ pmdb_sm_handler_client_read(struct raft_net_client_request_handle *rncr)
     ssize_t rrc = pmdb_object_lookup(&pmdb_req->pmdbrm_user_id, &obj,
                                     rncr->rncr_current_term);
 
-    if (!rrc)   // Ok.  Continue to read operation
+    if (!rrc || dont_comp_rncui_for_rd)   // Ok.  Continue to read operation
     {
         rrc = pmdbApi->pmdb_read(&pmdb_req->pmdbrm_user_id,
                                  pmdb_req->pmdbrm_data,
@@ -902,9 +903,11 @@ _PmdbExec(const char *raft_uuid_str, const char *raft_instance_uuid_str,
 int
 PmdbExec(const char *raft_uuid_str, const char *raft_instance_uuid_str,
          const struct PmdbAPI *pmdb_api, const char *cf_names[],
-         int num_cf_names, bool use_synchronous_writes, void *user_data)
+         int num_cf_names, bool use_synchronous_writes,
+         bool ignore_rncui, void *user_data)
 {
     pmdb_user_data = user_data;
+    dont_comp_rncui_for_rd = ignore_rncui;
     return _PmdbExec(raft_uuid_str, raft_instance_uuid_str, pmdb_api, cf_names,
 					 num_cf_names, use_synchronous_writes);
 }

--- a/test/pumice-reference-server.c
+++ b/test/pumice-reference-server.c
@@ -359,5 +359,5 @@ main(int argc, char **argv)
     const char *cf_names[1] = {pmdbts_column_family_name};
 
     return PmdbExec(raft_uuid_str, my_uuid_str, &api, cf_names, 1,
-                    syncPMDBWrites, NULL);
+                    syncPMDBWrites, false, NULL);
 }


### PR DESCRIPTION
Most of the Pumicedb application do not have
to compare the rncui during read operation.
Addded parameter to PmdbExec() to set
ignore_rncui_check_during_read. This will allow the
read operation for the key even if rncui with which it
was written is not same.