### PR TITLE
Fixed memory leak for follower.

### DIFF
--- a/src/pumice_db.c
+++ b/src/pumice_db.c
@@ -969,8 +969,9 @@ pmdb_sm_handler_pmdb_sm_apply(const struct pmdb_msg *pmdb_req,
                             pmdb_req->pmdbrm_data_size, (void *)&pah,
                             pmdb_user_data);
 
-    // rc of 0 means the client will get a reply
-    if (!rc)
+    // rc of 0 means the client will get a reply and only leader should send the
+    // reply back to client.
+    if (!rc && rncr->rncr_is_leader)
     {
         struct pmdb_msg *pmdb_reply =
             RAFT_NET_MAP_RPC(pmdb_msg, rncr->rncr_reply);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -4698,17 +4698,10 @@ raft_server_state_machine_apply(struct raft_instance *ri)
 
         rc_arr[i] = ri->ri_server_sm_request_cb(&rncr[i]);
 
-        /*
-         * On ri_server_sm_request_cb() failure, memory for write
-         * supplement would have not been allocated and ws merge
-         * should not happen.
-         * XXX Should we fail the entire coalesced write transaction
-         * in case any of the write transaction fails?
-         */
         if (rc_arr[i])
             failed = true;
-        else
-            raft_net_sm_write_supplements_merge(&coalesced_ws,
+
+        raft_net_sm_write_supplements_merge(&coalesced_ws,
                                             &rncr_ptr->rncr_sm_write_supp);
 
         offset += reh.reh_entry_sz[i];
@@ -4752,7 +4745,7 @@ raft_server_state_machine_apply(struct raft_instance *ri)
           * is a follower.  Therefore, udp init should be bypassed if this
           * node is not the leader.
           */
-         if (!rc_arr[i] &&
+         if (!rc_arr[i] && raft_instance_is_leader(ri) &&
              raft_net_client_request_handle_has_reply_info(&rncr[i]))
             raft_server_client_reply_init(
                 ri, &rncr[i], RAFT_CLIENT_RPC_MSG_TYPE_REPLY);


### PR DESCRIPTION
ri_server_sm_request_cb() could fail for
followers as pmdb object was only written for
leader during write phase. And it is expected
ri_server_sm_request_cb() to fail for followers.
raft_net_sm_write_supplements_merge() should get
called even if ri_server_sm_request_cb() returns
error.