### PR TITLE
Allow retry on request if tcp connection is not established yet.

### DIFF
--- a/src/raft_client.c
+++ b/src/raft_client.c
@@ -1859,7 +1859,8 @@ raft_client_rpc_sendq_dequeue_head_and_send(struct raft_client_instance *rci)
     {
         rc = raft_client_rpc_launch(rci, sa);
 
-        if (rc)
+        // Dont' mark rcrh_cancel if rc is EAGAIN.
+        if (rc && rc != -EAGAIN)
         {
             cancel = true;
             /* msg failed to send - notify the app layer.  Use the RCI_LOCK on

--- a/src/raft_net.c
+++ b/src/raft_net.c
@@ -1738,7 +1738,7 @@ raft_net_send_msg(struct raft_instance *ri, struct ctl_svc_node *csn,
     if (size_rc == msg_size)
         raft_net_update_last_comm_time(ri, csn->csn_uuid, true);
 
-    return size_rc == msg_size ? 0 : -ECOMM;
+    return size_rc == msg_size ? 0 : size_rc;
 }
 
 int


### PR DESCRIPTION
tcp_mgr_connection_verify() returns -EAGAIN if connection
is not established between the peers.
But this error sets rcrh_cancel and request never gets
retried. Request will remain in subapp tree till timeout
and later will be removed.
Allow returning actual return code to make sure the request
can be retired later.
This issue was visible with key-value size larger than 65K
and data transfer happens through tcp.