### PR TITLE
Removed coalesced item from tree only pmdb object found.

### DIFF
--- a/src/pumice_db.c
+++ b/src/pumice_db.c
@@ -899,7 +899,8 @@ pmdb_sm_handler_pmdb_sm_apply_remove_coalesce_tree_item(
             raft_net_client_user_id_to_string(rncui, rncr_rncui_str, 129);
 
             FATAL_IF(
-                1, "unmatching client / cowr (%s, %s) uuid or rncui (%s, %s),"
+                1, "unmatching cowr client / rncr client (%s, %s),"
+                " or cowr rncui / rncr rncui (%s, %s),"
                 " or cowr_sa term: %ld/ rncr term: %ld",
                 cowr_uuid, client_uuid, cowr_rncui_str, rncr_rncui_str,
                 cowr_sa->pcwsa_current_term, rncr->rncr_current_term);


### PR DESCRIPTION
In apply phase, check for stale item in coalesced
sa tree only if pmdb_object_lookup() is successful.
If pmdb object is found on the leader then only
rncr_client_uuid would get initialised.
And we won't hit the assert in
pmdb_sm_handler_pmdb_sm_apply_remove_coalesce_tree_item()
in case rncr was uninitialized due to pmdb_object_lookup()
couldn't find the pmdb object.