### PR TITLE
tcp sockets should be closed before epoll cleanup.

### DIFF
--- a/.github/workflows/niova-bulk-recovery.yml
+++ b/.github/workflows/niova-bulk-recovery.yml
@@ -67,17 +67,28 @@ jobs:
     - name: Create log directory for storing holon logs
       run: mkdir  /home/runner/work/niovad/niovad/holon_log
 
+    - name: Create ssh key
+      run: >
+           ssh-keygen -t rsa -b 4096 -N '' -f ~/.ssh/id_rsa
 
-    - name: Allow localhost to ssh to itself for rsync to work
-      run: ssh-keygen -N '' <<<$'\ny\n' &&
-           cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys &&
-           echo "NoHostAuthenticationForLocalhost yes" > ~/.ssh/config &&
-           echo "StrictHostKeyChecking no" >> ~/.ssh/config
+    - name: Add key to auth file
+      run: >
+           cat ~/.ssh/id_rsa.pub | tee -a ~/.ssh/authorized_keys
 
-    - name: check authorized_keys
-      run: cat ~/.ssh/authorized_keys &&
-           cat ~/.ssh/config
+    - name: Allow localhost authentication
+      run: >
+           echo "NoHostAuthenticationForLocalhost yes" > ~/.ssh/config
 
+    - name: Ensure the owner of the key is correct
+      run: |
+           chmod 600 ~/.ssh/authorized_keys
+           chmod 700 ~/.ssh
+           sudo chmod -c 0755 ~/
+           ls -la ~/.ssh
+
+    - name: Test SSH connection to localhost
+      run: >
+           ssh -vvv -i ~/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no $(whoami)@localhost
 
     - name:  run recipes
       run: cd /home/runner/work/niovad/niovad/build_dir/holon/ &&

--- a/scripts/run-recipes.sh
+++ b/scripts/run-recipes.sh
@@ -21,15 +21,6 @@ while IFS= read -r line; do
    recipe_list+=("$line")
 done <$RECIPE_FILE
 
-# Generate ssh-keys
-#ssh-keygen -N '' <<<$'\ny\n'
-
-# Copy pub key to authorized_keys
-#cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-
-# NoHostAuthenticationForLocalhost
-#echo "NoHostAuthenticationForLocalhost yes" > ~/.ssh/config
-
 for recipe in "${recipe_list[@]}"
 do
    ansible-playbook -e 'srv_port=4000' -e npeers=$NPEERS -e dir_path=$LOG_PATH -e 'client_port=14000' -e recipe=$recipe -e 'backend_type=pumicedb' -e app_name=$APP_TYPE -e coalesced_wr=$ENABLE_COALESCED_WR holon.yml


### PR DESCRIPTION
raft_net_epoll_cleanup()->epoll_mgr_close() was failing
because there epoll_mgr_tally_handles() was returning 2
i.e there are still two epoll_handles in the epoll_mgr.

The epoll_handles for which raft_net_epoll_cleanup()
can not delete the handle are added by
tcp_mgr_epoll_setup()->tcp_mgr_connection_epoll_add()

But in raft_net_instance_shutdown(), raft_net_epoll_cleanup()
gets called first , which now fails as tmi_listen_eph
is still not deleted.

Solution:
Close the socket before epoll_cleanup, so that epoll_mgr_tally_handles
will not find any entries in the epoll hander list.