### PR TITLE
Update the rci_leader_csn on redirect leader reply.

### DIFF
--- a/src/raft_client.c
+++ b/src/raft_client.c
@@ -1215,7 +1215,9 @@ raft_client_update_leader_from_redirect(struct raft_client_instance *rci,
     int rc = raft_net_apply_leader_redirect(RCI_2_RI(rci),
                                             rcrm->rcrm_redirect_id,
                                             raftClientStaleServerTimeMS);
-    rci->rci_leader_csn = RCI_2_RI(rci)->ri_csn_leader;
+    if (!rc)
+        rci->rci_leader_csn = RCI_2_RI(rci)->ri_csn_leader;
+
     DBG_RAFT_CLIENT_RPC_SOCK((rc ? LL_NOTIFY : LL_DEBUG), rcrm, from,
                              "raft_net_apply_leader_redirect(): %s",
                              strerror(-rc));


### PR DESCRIPTION
rci_leader_csn do not get updated immediately even
after the reply is received from server about different
leader. Client will see leader not viable for long time
in that case.
Update rci_leader_csn immediately in
raft_client_update_leader_from_redirect()