### PR TITLE
Add leader quorum counter update to be used as a global clock

### DIFF
--- a/src/include/raft.h
+++ b/src/include/raft.h
@@ -315,6 +315,8 @@ struct raft_leader_state
     int64_t                   rls_initial_term_idx; // idx @start of ldr's term
     int64_t                   rls_leader_term;
     int64_t                   rls_quorum_ok_cnt;
+    struct timespec           rls_leader_start;
+    struct timespec           rls_leader_accumulated;
 //    int64_t                   rls_quorum_miss_cnt;
     struct raft_follower_info rls_rfi[CTL_SVC_MAX_RAFT_PEERS];
 };


### PR DESCRIPTION
This patch adds a counter which is incremented by the leader each time raft_leader_check_quorum() is called.  Note that the assumption is that raft_leader_check_quorum() will only be called by the timerfd cb when the leader's heartbeat timer expires.

The json ctl-interface members have been added and are only active when the peer is the leader.  The quorum-cnt, taken with the 'term' can provide a monotonic counter which typically increments at a frequency of heartbeat-freq-mseq.  Note that when the cluster is undergoing a leader election or has suffered a long-duraction quorum loss, the counter will not advance at all (though the term value may be advancing).

{
  "quorum-cnt" : 16162,
  "heartbeat-freq-mseq" : 30,
}

The use case is for supplying control-plane users with a clock source for time-based leased locks.  We first expect this to be used with VDEV leases.