### PR TITLE
Separate timerfd leader duties in raft_server

### DIFF
--- a/src/include/raft.h
+++ b/src/include/raft.h
@@ -43,6 +43,11 @@
 #define RAFT_ELECTION_UPPER_TIME_MS 300
 #define RAFT_ELECTION_RANGE_DIVISOR 2.0
 
+// Raft leader wakes up every RAFT_LEADER_WAKEUP_MS
+#define RAFT_LEADER_WAKEUP_MS 2ULL
+#define RAFT_SERVER_COALESCE_TIMEOUT_FACTOR 2 // * RAFT_LEADER_WAKEUP_MS
+#define RAFT_SERVER_HEARTBEAT_ISSUE_FACTOR 10 // * RAFT_LEADER_WAKEUP_MS
+
 // Leader steps down after this many cycles following quorum loss
 #define RAFT_ELECTION_CHECK_QUORUM_FACTOR 10
 
@@ -549,7 +554,7 @@ raft_compile_time_checks(void)
     COMPILE_TIME_ASSERT(sizeof(struct raft_entry_header) ==
                         RAFT_ENTRY_HEADER_RESERVE);
     COMPILE_TIME_ASSERT((RAFT_ELECTION_UPPER_TIME_MS /
-                         RAFT_HEARTBEAT_FREQ_PER_ELECTION) >
+                         RAFT_HEARTBEAT_FREQ_PER_ELECTION) >=
                         RAFT_HEARTBEAT__MIN_TIME_MS);
 }
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1651,6 +1651,12 @@ raft_election_timeout_set(const struct raft_instance *ri, struct timespec *ts)
 }
 
 static unsigned long long
+raft_leader_wakeup_freq_msec(void)
+{
+    return RAFT_LEADER_WAKEUP_MS;
+}
+
+static unsigned long long
 raft_heartbeat_timeout_msec(const struct raft_instance *ri)
 {
     NIOVA_ASSERT(ri);
@@ -1663,10 +1669,18 @@ raft_heartbeat_timeout_msec(const struct raft_instance *ri)
     return msec;
 }
 
+#if 0
 static void
-raft_heartbeat_timeout_sec(const struct raft_instance *ri, struct timespec *ts)
+raft_heartbeat_timeout_set(const struct raft_instance *ri, struct timespec *ts)
 {
     msec_2_timespec(ts, raft_heartbeat_timeout_msec(ri));
+}
+#endif
+
+static void
+raft_leader_timeout_set(struct timespec *ts)
+{
+    msec_2_timespec(ts, raft_leader_wakeup_freq_msec());
 }
 
 /**
@@ -1680,7 +1694,7 @@ raft_server_timerfd_settime(struct raft_instance *ri)
 
     if (ri->ri_state == RAFT_STATE_LEADER)
     {
-        raft_heartbeat_timeout_sec(ri, &its.it_value);
+        raft_leader_timeout_set(&its.it_value);
         its.it_interval = its.it_value;
     }
     else
@@ -2636,6 +2650,24 @@ raft_server_increment_leader_time(struct raft_instance *ri)
 }
 
 static raft_net_timerfd_cb_ctx_t
+raft_server_timerfd_leader_cb(struct raft_instance *ri)
+{
+    static size_t cnt;
+    cnt++;
+
+    if (!raft_leader_check_quorum(ri)) // bail if quorum loss is detected
+        raft_server_become_candidate(ri, true);
+
+    if ((cnt % RAFT_SERVER_COALESCE_TIMEOUT_FACTOR) == 0)
+        raft_server_leader_co_wr_timer_expired(ri);
+
+    if ((cnt % RAFT_SERVER_HEARTBEAT_ISSUE_FACTOR) == 0)
+        raft_server_issue_heartbeat(ri);
+
+    raft_server_increment_leader_time(ri);
+}
+
+static raft_net_timerfd_cb_ctx_t
 raft_server_timerfd_cb(struct raft_instance *ri)
 {
     FUNC_ENTRY(LL_TRACE);
@@ -2649,17 +2681,9 @@ raft_server_timerfd_cb(struct raft_instance *ri)
         break;
 
     case RAFT_STATE_LEADER:
-        if (raft_leader_check_quorum(ri))
-        {
-            raft_server_leader_co_wr_timer_expired(ri);
-            raft_server_issue_heartbeat(ri);
-            raft_server_increment_leader_time(ri);
-        }
-        else
-        {
-            raft_server_become_candidate(ri, true);
-        }
+        raft_server_timerfd_leader_cb(ri);
         break;
+
     default:
         break;
     }


### PR DESCRIPTION
This patch allows the coalesce buffer and the heartbeat issuance to occur independently per timer expire.