### PR TITLE
Thread control startup race fix / convert bitfield into CAS flags

### DIFF
--- a/src/include/atomic.h
+++ b/src/include/atomic.h
@@ -23,7 +23,7 @@ typedef volatile signed char   niova_atomic8_t;
 #define niova_atomic_xor __sync_xor_and_fetch
 
 // type __sync_and_and_fetch (type *ptr, type value, ...)
-#define niova_atomic_and __sync_xor_and_fetch
+#define niova_atomic_and __sync_and_and_fetch
 
 #define niova_atomic_inc(ptr)           __sync_add_and_fetch(ptr, 1)
 #define niova_atomic_fetch_and_inc(ptr) __sync_fetch_and_add(ptr, 1)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -5369,8 +5369,6 @@ raft_server_sync_thread(void *arg)
     if (!ri->ri_sync_freq_us)
         ri->ri_sync_freq_us = RAFT_SERVER_SYNC_FREQ_US;
 
-//    thread_ctl_set_user_pause_usec(tc, ri->ri_sync_freq_us);
-
     NIOVA_ASSERT(ri);
 
     THREAD_LOOP_WITH_CTL(tc)
@@ -5577,8 +5575,6 @@ raft_server_chkpt_thread(void *arg)
 {
     struct thread_ctl *tc = arg;
     struct raft_instance *ri = (struct raft_instance *)thread_ctl_get_arg(tc);
-
-//    thread_ctl_set_user_pause_usec(tc, ri->ri_sync_freq_us);
 
     NIOVA_ASSERT(ri);
 

--- a/src/util_thread.c
+++ b/src/util_thread.c
@@ -127,7 +127,9 @@ util_thread_main(void *arg)
     FUNC_ENTRY(LL_DEBUG);
 
     struct thread_ctl *tc = arg;
-    tc->tc_is_utility_thread = 1;
+
+    int rc = thread_ctl_set_flag(tc, TC_FLAG_IS_UTILITY_THR);
+    NIOVA_ASSERT(rc == 0);
 
     thread_ctl_set_self(tc);
 

--- a/src/watchdog.c
+++ b/src/watchdog.c
@@ -193,7 +193,8 @@ watchdog_svc_thread(void *arg)
     struct thread_ctl *tc = arg;
     NIOVA_ASSERT(tc);
 
-    tc->tc_is_watchdog_thread = 1;
+    int rc = thread_ctl_set_flag(tc, TC_FLAG_IS_WATCHDOG_THR);
+    NIOVA_ASSERT(rc == 0);
 
     thread_ctl_set_self(tc);
 


### PR DESCRIPTION
The bitfield flags are now replaced with an enum of bitwise flags.

thread_ctl gets some methods to test and set the flags using atomic operations.

(cherry picked from commit 77c72da62a7c64d31b01fb99131f85e7b434c9bb)