### PR TITLE
Add 'alternative' buffer source to buffer set

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: apt update
       run: sudo apt update
     - name: dpkg / rpm prep (debug)

--- a/.github/workflows/controlplane-recipes.yml
+++ b/.github/workflows/controlplane-recipes.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -65,7 +65,7 @@ jobs:
 
     # Checkout holon repo
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -111,7 +111,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/golang-apps-recipes.yml
+++ b/.github/workflows/golang-apps-recipes.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -59,7 +59,7 @@ jobs:
            cp ./code/scripts/covid_app_recipe.txt ./code/scripts/foodpalaceapp_recipe.txt /home/runner/work/niovad/niovad/build_dir/
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -129,7 +129,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/lease_recipes.yml
+++ b/.github/workflows/lease_recipes.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -64,7 +64,7 @@ jobs:
 
     # Checkout holon repo
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -104,7 +104,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/lease_stale_recipes.yml
+++ b/.github/workflows/lease_stale_recipes.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -64,7 +64,7 @@ jobs:
 
     # Checkout holon repo
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
          #ref:
@@ -93,7 +93,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/niova-basic-recipes.yml
+++ b/.github/workflows/niova-basic-recipes.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -57,7 +57,7 @@ jobs:
       run: cp ./code/scripts/basic_recipes_with_sync.txt /home/runner/work/niovad/niovad/build_dir/
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -98,7 +98,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/niova-bulk-recovery.yml
+++ b/.github/workflows/niova-bulk-recovery.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -55,7 +55,7 @@ jobs:
            cp ./code/scripts/bulk_recovery_recipes.txt /home/runner/work/niovad/niovad/build_dir/
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -107,7 +107,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/niova-coalesced-wr.yml
+++ b/.github/workflows/niova-coalesced-wr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -55,7 +55,7 @@ jobs:
            cp ./code/scripts/coalesced_wr_recipes_with_sync.txt /home/runner/work/niovad/niovad/build_dir/
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -100,7 +100,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/niova-fail-over.yml
+++ b/.github/workflows/niova-fail-over.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -45,7 +45,7 @@ jobs:
            cp ./code/scripts/failover_recipes.txt /home/runner/work/niovad/niovad/build_dir/
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -77,7 +77,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/niova-prevote.yml
+++ b/.github/workflows/niova-prevote.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -54,7 +54,7 @@ jobs:
            cp ./code/scripts/prevote_recipes.txt /home/runner/work/niovad/niovad/build_dir/
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -83,7 +83,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/.github/workflows/niova-rebuild.yml
+++ b/.github/workflows/niova-rebuild.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ./code
 
@@ -45,7 +45,7 @@ jobs:
            cp ./code/scripts/rebuild_recipes.txt /home/runner/work/niovad/niovad/build_dir/
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
        repository: 00pauln00/holon
        #ref:
@@ -77,7 +77,7 @@ jobs:
       if: failure()
 
     - name: Archive the test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
          name: ${{ steps.prepare_artifact_filename.outputs.ARTIFACT_NAME }}
          path: /home/runner/work/niovad/niovad/holon_log

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -22,6 +22,7 @@ enum buffer_set_opts
     BUFSET_OPT_LREG            = (1 << 2),
     BUFSET_OPT_MEMALIGN_L2     = (1 << 3),
     BUFSET_OPT_MEMALIGN_SECTOR = (1 << 4),
+    BUFSET_OPT_ALT_SOURCE_BUF  = (1 << 5),
     BUFSET_OPT_MEMALIGN        = BUFSET_OPT_MEMALIGN_SECTOR,
 };
 
@@ -48,24 +49,38 @@ SLIST_HEAD(buffer_user_slist, buffer_item);
 
 #define BUFFER_SET_NAME_MAX 32
 
+struct buffer_set_args
+{
+    struct buffer_set   *bsa_set;
+    size_t               bsa_nbufs;
+    size_t               bsa_buf_size;
+    void                *bsa_alt_source;
+    size_t               bsa_alt_source_size;
+    size_t               bsa_alt_source_used;
+    enum buffer_set_opts bsa_opts;
+};
+
 struct buffer_set
 {
-    char                    bs_name[BUFFER_SET_NAME_MAX + 1];
-    size_t                  bs_num_bufs;
-    ssize_t                 bs_num_allocated;
-    ssize_t                 bs_num_user_cached;
-    ssize_t                 bs_num_pndg_alloc;
-    size_t                  bs_item_size;
-    size_t                  bs_max_allocated;
-    size_t                  bs_total_alloc;
-    uint8_t                 bs_init:1;
-    uint8_t                 bs_serialize:1;
-    uint8_t                 bs_ctl_interface:1;
-    uint8_t                 bs_allow_user_cache:1;
-    struct buffer_list      bs_free_list;
-    struct buffer_list      bs_inuse_list;
-    pthread_mutex_t         bs_mutex;
-    struct lreg_node        bs_lrn;
+    char                bs_name[BUFFER_SET_NAME_MAX + 1];
+    size_t              bs_num_bufs;
+    ssize_t             bs_num_allocated;
+    ssize_t             bs_num_user_cached;
+    ssize_t             bs_num_pndg_alloc;
+    size_t              bs_item_size;
+    size_t              bs_max_allocated;
+    size_t              bs_total_alloc;
+    uint8_t             bs_init:1;
+    uint8_t             bs_serialize:1;
+    uint8_t             bs_ctl_interface:1;
+    uint8_t             bs_allow_user_cache:1;
+    uint8_t             bs_use_alt_source_buf:1;
+    void               *bs_alt_source_buf;
+    size_t              bs_alt_source_buf_size;
+    struct buffer_list  bs_free_list;
+    struct buffer_list  bs_inuse_list;
+    pthread_mutex_t     bs_mutex;
+    struct lreg_node    bs_lrn;
 };
 
 size_t
@@ -110,6 +125,9 @@ buffer_set_destroy(struct buffer_set *bs);
 int
 buffer_set_init(struct buffer_set *bs, size_t nbufs, size_t buf_size,
                 enum buffer_set_opts opts);
+
+int
+buffer_set_initx(struct buffer_set_args *bsa);
 
 static inline ssize_t
 buffer_user_list_total_bytes(const struct buffer_user_slist *bus,


### PR DESCRIPTION
This allows the user of a buffer set to allocate the set with a provided source buffer.

A new init function, buffer_set_initx(), has been added which takes a parameter structure that holds the provided buffer information.