### PR TITLE
raft-net-info ctl-interface bits moved into raft_root_entry

### DIFF
--- a/scripts/raft.sh
+++ b/scripts/raft.sh
@@ -39,6 +39,6 @@ fi
 # async mode add "-a"
 
 LD_LIBRARY_PATH=/usr/local/niova/lib \
-               gdb -ex=r --args /usr/local/niova/libexec/niova/NKV_pmdbServer \
+               gdb -ex=r --args /usr/local/niova/libexec/niova/raft-reference-server \
                -r ${RAFT_UUID} -u ${PEER_UUID} 2> /tmp/${PEER_UUID}.peer
 

--- a/src/include/raft_net.h
+++ b/src/include/raft_net.h
@@ -791,4 +791,8 @@ int
 raft_net_sm_write_supplements_merge(struct raft_net_sm_write_supplements *dest,
                                     struct raft_net_sm_write_supplements *src);
 
+util_thread_ctx_reg_int_t
+raft_net_lreg_cb(enum lreg_node_cb_ops op, struct lreg_node *lrn,
+                 struct lreg_value *lv);
+
 #endif


### PR DESCRIPTION
    "raft_root_entry" : [
                {
                        "raft-uuid" : "8726c606-2cee-11f0-8cbf-637d43e21752",
                        "peer-uuid" : "8729998a-2cee-11f0-8857-37646ecb1f0c",
.....
                        "raft-net-info" : {
                                "ignore_timer_events" : false,
                                "election-timeout-ms" : 300,
                                "heartbeat-freq-per-election-timeout" : 10,
                                "max-scan-entries" : 0,
                                "log-reap-factor" : 0,
                                "num-checkpoints" : 0,
                                "auto-checkpoint-enabled" : false
                        },
                        "coalesce-items-pending" : -1,
                        "coalesce-space-remaining" : -1,
                        "coalesced-wr-cnt" : {},
                        "dev-read-latency-usec" : {},
                        "dev-write-latency-usec" : {},
                        "dev-sync-latency-usec" : {},
                        "nentries-per-sync" : {},
                        "checkpoint-latency-usec" : {
                                "1" : 31
                        }
                }
        ],