### PR TITLE
Add nivoa_backtrace_dump_pc for when there's only 1 instruction address to trace

### DIFF
--- a/src/include/niova_backtrace.h
+++ b/src/include/niova_backtrace.h
@@ -7,7 +7,12 @@
 #ifndef _NIOVA_BACKTRACE_H_
 #define _NIOVA_BACKTRACE_H_ 1
 
+#include <stdint.h>
+
 void
 niova_backtrace_dump(void);
+
+void
+niova_backtrace_dump_pc(uintptr_t pc);
 
 #endif

--- a/src/niova_backtrace.c
+++ b/src/niova_backtrace.c
@@ -42,6 +42,18 @@ niova_backtrace_full_cb(void *data, uintptr_t pc, const char *filename, int line
 }
 
 void
+niova_backtrace_dump_pc(uintptr_t pc)
+{
+    pthread_mutex_lock(&niovaBacktraceMutex);
+    niovaBacktraceStackNum = 0;
+    if (niovaBacktraceState)
+        backtrace_pcinfo(niovaBacktraceState, pc, niova_backtrace_full_cb,
+                         niova_backtrace_error_cb, NULL);
+
+    pthread_mutex_unlock(&niovaBacktraceMutex);
+}
+
+void
 niova_backtrace_dump_simple(void)
 {
     pthread_mutex_lock(&niovaBacktraceMutex);


### PR DESCRIPTION
Sometimes you don't have a stack, but you still have a pc addr to decode