### PR TITLE
Add stack_num param to niova_backtrace_dump_pc

### DIFF
--- a/src/include/niova_backtrace.h
+++ b/src/include/niova_backtrace.h
@@ -13,6 +13,6 @@ void
 niova_backtrace_dump(void);
 
 void
-niova_backtrace_dump_pc(uintptr_t pc);
+niova_backtrace_dump_pc(uintptr_t pc, int stack_num);
 
 #endif

--- a/src/niova_backtrace.c
+++ b/src/niova_backtrace.c
@@ -42,10 +42,10 @@ niova_backtrace_full_cb(void *data, uintptr_t pc, const char *filename, int line
 }
 
 void
-niova_backtrace_dump_pc(uintptr_t pc)
+niova_backtrace_dump_pc(uintptr_t pc, int stack_num)
 {
     pthread_mutex_lock(&niovaBacktraceMutex);
-    niovaBacktraceStackNum = 0;
+    niovaBacktraceStackNum = stack_num;
     if (niovaBacktraceState)
         backtrace_pcinfo(niovaBacktraceState, pc, niova_backtrace_full_cb,
                          niova_backtrace_error_cb, NULL);


### PR DESCRIPTION
Allow caller to set what frame level the pc belongs to