### PR TITLE
NIOVA_ASSERT (and others): Add __builtin_unreachable()

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -265,18 +265,6 @@ do {                                                  \
     exit(exit_val);                                   \
 } while (0)
 
-#define NIOVA_ASSERT(cond)                    \
-do {                                          \
-    if (!(cond))                              \
-        FATAL_MSG("failed assertion: "#cond); \
-} while (0)
-
-#define NIOVA_ASSERT_strerror(cond)                                  \
-do {                                                                 \
-    if (!(cond))                                                     \
-        FATAL_MSG("failed assertion: "#cond", %s", strerror(errno)); \
-} while (0)
-
 #define DEBUG_BLOCK(lvl) \
     if (lvl <= log_level_get())
 

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -173,7 +173,10 @@ do {                                                                         \
                     thread_name_get(), __func__, __LINE__, ##__VA_ARGS__);   \
         }                                                                    \
         if ((usr_level) == LL_FATAL)                                         \
+        {                                                                    \
             LOG_ABORT;                                                       \
+            __builtin_unreachable();                                         \
+        }                                                                    \
     }                                                                        \
 } while (0)
 


### PR DESCRIPTION
niova-block has gcc compilation warnings that can be avoided
when the compiler knows that these macros have final endpoints.