### PR TITLE
ctl-interface: fix APPLY through compound vobject selectors

### DIFF
--- a/src/ctl_interface_cmd.c
+++ b/src/ctl_interface_cmd.c
@@ -362,23 +362,28 @@ ctlic_parse_token_value_GET(struct ctlic_matched_token *cmt)
         return -EINVAL;
 
     bool escape_char = false;
-    bool prev_char_was_solidus = false;
+    bool prev_char_was_separator = false;
     bool prev_char_was_at_sign = false;
 
     for (size_t i = 0; i < cmt->cmt_value_len; i++)
     {
+        const bool segment_separator =
+            cmt->cmt_value[i] == '/' ||
+            (cmt->cmt_token->ct_id == CT_ID_WHERE &&
+             cmt->cmt_value[i] == '&');
+
         if (cmt->cmt_value[i] == '\\')
         {
             escape_char = true;
             continue;
         }
-        else if (cmt->cmt_value[i] == '/' && !escape_char)
+        else if (segment_separator && !escape_char)
         {
             if (prev_char_was_at_sign)
                 return -EBADMSG;
 
             cmt->cmt_value[i] = '\0';
-            prev_char_was_solidus = true;
+            prev_char_was_separator = true;
             escape_char = false;
             continue;
         }
@@ -389,7 +394,7 @@ ctlic_parse_token_value_GET(struct ctlic_matched_token *cmt)
             escape_char = false;
             continue;
         }
-        else if (prev_char_was_solidus)
+        else if (prev_char_was_separator)
         {
             if (cmt->cmt_num_depth_segments == CTLIC_MAX_VALUE_DEPTH)
                 return -E2BIG;
@@ -402,7 +407,7 @@ ctlic_parse_token_value_GET(struct ctlic_matched_token *cmt)
         }
         else if (prev_char_was_at_sign)
         {
-            if (prev_char_was_solidus ||
+            if (prev_char_was_separator ||
                 cmt->cmt_num_depth_segments == 0 ||
                 cmt->cmt_num_depth_segments >= CTLIC_MAX_VALUE_DEPTH)
                 return -EBADMSG;
@@ -418,7 +423,7 @@ ctlic_parse_token_value_GET(struct ctlic_matched_token *cmt)
         }
 
         prev_char_was_at_sign = false;
-        prev_char_was_solidus = false;
+        prev_char_was_separator = false;
         escape_char = false;
     }
 
@@ -1166,6 +1171,65 @@ ctlic_scan_registry_cb(struct lreg_node *lrn, void *arg, const int depth);
 static bool
 ctlic_scan_registry_cb_CT_ID_WHERE(struct lreg_node *lrn,
                                    struct ctlic_iterator *parent_citer,
+                                   const unsigned int depth);
+
+static int
+ctlic_try_apply_to_value(struct lreg_node *lrn,
+                         const struct ctlic_request *cr,
+                         const struct lreg_value *lv)
+{
+    if (!lrn || !cr || !lv)
+        return -EINVAL;
+
+    if (LREG_VALUE_TO_REQ_TYPE(lv) == LREG_VAL_TYPE_VARRAY ||
+        LREG_VALUE_TO_REQ_TYPE(lv) == LREG_VAL_TYPE_VOBJECT)
+    {
+        struct lreg_node vnode = *lrn;
+
+        lreg_value_vnode_data_to_lreg_node(lv, &vnode);
+
+        return ctlic_try_apply_here(&vnode, cr);
+    }
+
+    return ctlic_try_apply_here(lrn, cr);
+}
+
+static bool
+ctlic_where_descend(struct lreg_node *lrn, struct ctlic_iterator *parent_citer,
+                    const struct lreg_value *lv, const unsigned int depth)
+{
+    if (!lrn || !parent_citer || !lv)
+        return false;
+
+    switch (LREG_VALUE_TO_REQ_TYPE(lv))
+    {
+    case LREG_VAL_TYPE_ARRAY:
+    case LREG_VAL_TYPE_OBJECT:
+    case LREG_VAL_TYPE_ANON_OBJECT:
+        lreg_node_walk(lrn, ctlic_scan_registry_cb, parent_citer, depth,
+                       LREG_VALUE_TO_USER_TYPE(lv));
+        break;
+    case LREG_VAL_TYPE_VARRAY:
+    case LREG_VAL_TYPE_VOBJECT:
+    {
+        struct lreg_node vnode = *lrn;
+
+        lreg_value_vnode_data_to_lreg_node(lv, &vnode);
+
+        lreg_node_walk(&vnode, ctlic_scan_registry_cb, parent_citer, depth,
+                       LREG_VALUE_TO_USER_TYPE(lv));
+        break;
+    }
+    default:
+        return ctlic_scan_registry_cb_CT_ID_WHERE(lrn, parent_citer, depth);
+    }
+
+    return true;
+}
+
+static bool
+ctlic_scan_registry_cb_CT_ID_WHERE(struct lreg_node *lrn,
+                                   struct ctlic_iterator *parent_citer,
                                    const unsigned int depth)
 {
     NIOVA_ASSERT(parent_citer && parent_citer->citer_cr && depth > 0);
@@ -1209,17 +1273,19 @@ ctlic_scan_registry_cb_CT_ID_WHERE(struct lreg_node *lrn,
             if (!match)
                 continue;
 
-            // Segment match, descend if max request depth wasn't reached
-            else if (cmt->cmt_num_depth_segments > depth &&
-                     lreg_value_is_array_or_object(&lv))
-                lreg_node_walk(lrn, ctlic_scan_registry_cb,
-                               (void *)parent_citer,
-                               depth + 1, LREG_VALUE_TO_USER_TYPE(&lv));
+            /* Segment match, descend if max request depth wasn't reached.
+             * Scalar matches act as selectors for the current object, so the
+             * next depth is evaluated against the same lrn.
+             */
+            else if (cmt->cmt_num_depth_segments > depth)
+            {
+                if (!ctlic_where_descend(lrn, parent_citer, &lv, depth + 1))
+                    return false;
+            }
 
             // Segment match and depth has been reached
-            else if (cmt->cmt_num_depth_segments == depth &&
-                     !lreg_value_is_array_or_object(&lv))
-                rc = ctlic_try_apply_here(lrn, cr);
+            else if (cmt->cmt_num_depth_segments == depth)
+                rc = ctlic_try_apply_to_value(lrn, cr, &lv);
         }
 
         if (rc)

--- a/test/registry-test.c
+++ b/test/registry-test.c
@@ -6,16 +6,136 @@
 
 #include "niova_backtrace.h"
 
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "ctor.h"
+#include "ctl_interface.h"
+#include "ctl_interface_cmd.h"
 #include "init.h"
 #include "registry.h"
 #include "log.h"
-//#include "ctl_interface.h"
 
 REGISTRY_ENTRY_FILE_GENERATE;
 
 LREG_ROOT_ENTRY_GENERATE(test_entry_init_ctx, LREG_USER_TYPE_UNIT_TEST0);
 LREG_ROOT_ENTRY_GENERATE(test_entry, LREG_USER_TYPE_UNIT_TEST1);
+LREG_ROOT_ENTRY_GENERATE(issue_799, LREG_USER_TYPE_UNIT_TEST0);
+
+struct issue_799_chunk
+{
+    struct lreg_node i799_lrn;
+    const char       *i799_vdev_uuid;
+    uint64_t          i799_number;
+    char              i799_shallow_status[LREG_VALUE_STRING_MAX + 1];
+};
+
+static int
+issue_799_merge_info_cb(enum lreg_node_cb_ops op, struct lreg_node *lrn,
+                        struct lreg_value *lv)
+{
+    struct issue_799_chunk *chunk = lrn->lrn_cb_arg;
+    NIOVA_ASSERT(chunk);
+
+    switch (op)
+    {
+    case LREG_NODE_CB_OP_GET_NAME:
+        if (!lv)
+            return -EINVAL;
+        strncpy(lv->lrv_key_string, "merge-info", LREG_VALUE_STRING_MAX);
+        lv->get.lrv_num_keys_out = 1;
+        break;
+    case LREG_NODE_CB_OP_READ_VAL:
+        if (!lv)
+            return -EINVAL;
+        if (lv->lrv_value_idx_in)
+            return -ERANGE;
+        lreg_value_fill_string(lv, "shallow-status",
+                               chunk->i799_shallow_status);
+        break;
+    case LREG_NODE_CB_OP_WRITE_VAL:
+        if (!lv)
+            return -EINVAL;
+        if (lv->lrv_value_idx_in)
+            return -ERANGE;
+        snprintf(chunk->i799_shallow_status,
+                 sizeof(chunk->i799_shallow_status), "%s",
+                 LREG_VALUE_TO_IN_STR(lv));
+        break;
+    case LREG_NODE_CB_OP_INSTALL_NODE:        // fall through
+    case LREG_NODE_CB_OP_INSTALL_QUEUED_NODE: // fall through
+    case LREG_NODE_CB_OP_DESTROY_NODE:
+        break;
+    default:
+        return -ENOENT;
+    }
+
+    return 0;
+}
+
+static int
+issue_799_chunk_cb(enum lreg_node_cb_ops op, struct lreg_node *lrn,
+                   struct lreg_value *lv)
+{
+    struct issue_799_chunk *chunk = lrn->lrn_cb_arg;
+    NIOVA_ASSERT(chunk);
+
+    switch (op)
+    {
+    case LREG_NODE_CB_OP_GET_NAME:
+        if (!lv)
+            return -EINVAL;
+        strncpy(lv->lrv_key_string, "chunk", LREG_VALUE_STRING_MAX);
+        lv->get.lrv_num_keys_out = 3;
+        break;
+    case LREG_NODE_CB_OP_READ_VAL:
+        if (!lv)
+            return -EINVAL;
+        switch (lv->lrv_value_idx_in)
+        {
+        case 0:
+            lreg_value_fill_unsigned(lv, "number", chunk->i799_number);
+            break;
+        case 1:
+            lreg_value_fill_string(lv, "vdev-uuid", chunk->i799_vdev_uuid);
+            break;
+        case 2:
+            lreg_value_fill_vobject(lv, "merge-info",
+                                    LREG_USER_TYPE_UNIT_TEST0,
+                                    issue_799_merge_info_cb);
+            break;
+        default:
+            return -ERANGE;
+        }
+        break;
+    case LREG_NODE_CB_OP_WRITE_VAL:
+        return -EOPNOTSUPP;
+    case LREG_NODE_CB_OP_INSTALL_NODE:        // fall through
+    case LREG_NODE_CB_OP_INSTALL_QUEUED_NODE: // fall through
+    case LREG_NODE_CB_OP_DESTROY_NODE:
+        break;
+    default:
+        return -ENOENT;
+    }
+
+    return 0;
+}
+
+static struct issue_799_chunk issue799Chunks[] = {
+    {
+        .i799_vdev_uuid = "00000000-0000-0000-0000-000000000001",
+        .i799_number = 7,
+        .i799_shallow_status = "idle",
+    },
+    {
+        .i799_vdev_uuid = "00000000-0000-0000-0000-000000000002",
+        .i799_number = 8,
+        .i799_shallow_status = "idle",
+    },
+};
 
 static int
 null_lrn_cb(enum lreg_node_cb_ops op, struct lreg_node *lrn,
@@ -75,11 +195,55 @@ registry_test_install_and_remove_node(void)
     registry_test_wait_for_install_or_removal(lrn, false);
 }
 
+static void
+registry_test_issue_799_apply_to_vobject(void)
+{
+    char tmpdir[] = "/tmp/niova-registry-issue-799-XXXXXX";
+
+    NIOVA_ASSERT(mkdtemp(tmpdir));
+
+    int dirfd = open(tmpdir, O_RDONLY | O_DIRECTORY);
+    NIOVA_ASSERT(dirfd >= 0);
+
+    int cmdfd = openat(dirfd, "cmd", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    NIOVA_ASSERT(cmdfd >= 0);
+
+    int rc = dprintf(
+        cmdfd,
+        "APPLY shallow-status@merge\n"
+        "WHERE /issue_799/number@7&vdev-uuid@%s/merge-info\n"
+        "OUTFILE /out\n",
+        issue799Chunks[0].i799_vdev_uuid);
+    NIOVA_ASSERT(rc > 0);
+    NIOVA_ASSERT(!close(cmdfd));
+
+    struct ctli_cmd_handle cch = {
+        .ctlih_reg_user_type = LREG_USER_TYPE_ANY,
+        .ctlih_output_dirfd = dirfd,
+        .ctlih_input_dirfd = dirfd,
+        .ctlih_input_file_name = "cmd",
+    };
+
+    rc = ctlic_process_request(&cch);
+    NIOVA_ASSERT(!rc);
+
+    NIOVA_ASSERT(!strncmp(issue799Chunks[0].i799_shallow_status, "merge",
+                          LREG_VALUE_STRING_MAX));
+    NIOVA_ASSERT(!strncmp(issue799Chunks[1].i799_shallow_status, "idle",
+                          LREG_VALUE_STRING_MAX));
+
+    NIOVA_ASSERT(!unlinkat(dirfd, "cmd", 0));
+    NIOVA_ASSERT(!unlinkat(dirfd, "out", 0));
+    NIOVA_ASSERT(!close(dirfd));
+    NIOVA_ASSERT(!rmdir(tmpdir));
+}
+
 int
 main(void)
 {
     FUNC_ENTRY(LL_WARN);
     registry_test_install_and_remove_node();
+    registry_test_issue_799_apply_to_vobject();
 
     return 0;
 }
@@ -96,6 +260,7 @@ registry_test_init(void)
 
     // Install via macro which wraps lreg_node_install()
     LREG_ROOT_ENTRY_INSTALL(test_entry_init_ctx);
+    LREG_ROOT_ENTRY_INSTALL(issue_799);
 
     struct lreg_node *lrn = LREG_ROOT_ENTRY_PTR(test_entry_init_ctx);
 
@@ -142,6 +307,16 @@ registry_test_init(void)
     rc = lreg_node_install(&test_lrn, &null_lrn);
     NIOVA_ASSERT(rc == -EINVAL);
 
+    for (size_t i = 0; i < ARRAY_SIZE(issue799Chunks); i++)
+    {
+        lreg_node_init(&issue799Chunks[i].i799_lrn,
+                       LREG_USER_TYPE_UNIT_TEST0, issue_799_chunk_cb,
+                       &issue799Chunks[i], LREG_INIT_OPT_NONE);
+        rc = lreg_node_install(&issue799Chunks[i].i799_lrn,
+                               LREG_ROOT_ENTRY_PTR(issue_799));
+        NIOVA_ASSERT(!rc);
+    }
+
     // Removing 'lrn' should fail w/ -EBUSY since it has a child
     rc = lreg_node_remove(lrn, lreg_root_node_get());
     NIOVA_ASSERT(rc == -EBUSY);
@@ -178,6 +353,14 @@ registry_test_destroy(void)
 
     // Remove the lrn entry now w/ the macro (equiv to lreg_node_remove())
     LREG_ROOT_ENTRY_REMOVE(test_entry_init_ctx);
+
+    for (size_t i = 0; i < ARRAY_SIZE(issue799Chunks); i++)
+    {
+        rc = lreg_node_remove(&issue799Chunks[i].i799_lrn,
+                              LREG_ROOT_ENTRY_PTR(issue_799));
+        NIOVA_ASSERT(!rc);
+    }
+    LREG_ROOT_ENTRY_REMOVE(issue_799);
 
     if (lreg_node_is_installed(lrn) || lrn->lrn_async_remove)
     {


### PR DESCRIPTION
Support compound WHERE selectors with '&' so multiple predicates can match the same registry object before traversal continues.  This allows commands like:

  WHERE /nisd_chunks/number@7&vdev-uuid@UUID/merge-info

to select the intended chunk and then apply to nested vobject fields such as merge-info/shallow-status.

Also update WHERE traversal to descend through virtual arrays/objects and keep scalar matches as selectors on the current object when additional path segments remain.

Add a registry-test regression for Issue #799.